### PR TITLE
Preventing the nix build from using precompiled headers

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,7 @@ let
         export CC=${pkgs.afl}/bin/afl-gcc
         export CXX=${pkgs.afl}/bin/afl-g++
         export CFLAGS="-O3 -funroll-loops"
+        export PRECOMPILE_HEADERS=0
       }
   '');
 


### PR DESCRIPTION
Hey! 

Thanks a lot for this repo! It made my life really easy this evening :)

The afl nix build is broken with the current master. 

Luckily, this is a trivial fix.

-------------------------

Some pre-compiled headers are used to speed up the nix build.

The nix build system is trying detect whether g++ or clang is in use
in order to point the compiler to the right pre-compiled headers. This
check obviously fails here since we are using afl-g++ as CXX compiler.

We don't really care about those pre-compiled headers in a fuzzing
context. Disabling their use altogether.